### PR TITLE
feat: add operator-config ConfigMap to Helm chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/helm/frappe-operator/templates/configmap.yaml
+++ b/helm/frappe-operator/templates/configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frappe-operator-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "frappe-operator.labels" . | nindent 4 }}
+data:
+  # Default domain suffix for auto-detected sites
+  # Override per-bench or per-site as needed
+  defaultDomainSuffix: {{ .Values.operatorConfig.defaultDomainSuffix | quote }}
+  
+  # Ingress controller service to detect domain from
+  ingressControllerService: {{ .Values.operatorConfig.ingressControllerService | quote }}
+  ingressControllerNamespace: {{ .Values.operatorConfig.ingressControllerNamespace | quote }}
+  
+  # Git configuration
+  # Set to "false" to disable Git-based app installation (enterprise mode)
+  # Individual benches can override this setting
+  gitEnabled: {{ .Values.operatorConfig.gitEnabled | quote }}
+  
+  # FPM CLI path in container
+  fpmCliPath: {{ .Values.operatorConfig.fpmCliPath | quote }}
+  
+  # FPM default repositories (JSON array)
+  # These repositories are available to all benches
+  # Benches can add additional repositories in their spec
+  fpmRepositories: |
+{{- .Values.operatorConfig.fpmRepositories | nindent 4 }}

--- a/helm/frappe-operator/templates/namespace.yaml
+++ b/helm/frappe-operator/templates/namespace.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.global.operatorNamespace }}
-  labels:
-    {{- include "frappe-operator.labels" . | nindent 4 }}
-    control-plane: controller-manager
-
-

--- a/helm/frappe-operator/values.yaml
+++ b/helm/frappe-operator/values.yaml
@@ -97,6 +97,36 @@ keda:
   enabled: true
   # KEDA will be installed as a subchart for worker autoscaling
   # See: https://keda.sh/
+
+# Operator runtime configuration
+operatorConfig:
+  # Default domain suffix for auto-detected sites
+  # Override per-bench or per-site as needed
+  defaultDomainSuffix: ".myplatform.com"
+  
+  # Ingress controller service to detect domain from
+  ingressControllerService: "ingress-nginx-controller"
+  ingressControllerNamespace: "ingress-nginx"
+  
+  # Git configuration
+  # Set to "false" to disable Git-based app installation (enterprise mode)
+  # Individual benches can override this setting
+  gitEnabled: "false"
+  
+  # FPM CLI path in container
+  fpmCliPath: "/usr/local/bin/fpm"
+  
+  # FPM default repositories (JSON array)
+  # These repositories are available to all benches
+  # Benches can add additional repositories in their spec
+  fpmRepositories: |
+    [
+      {
+        "name": "frappe-community",
+        "url": "https://fpm.frappe.io",
+        "priority": 100
+      }
+    ]
   
   # Override KEDA values if needed
   # resources:


### PR DESCRIPTION
## Changes

- Added  template to Helm chart with operator runtime configuration
- Added  values section for domain detection, Git config, and FPM settings  
- Removed  template (use  flag instead)
- Updated CI workflow to tag main branch builds as 'latest'

## Why

The operator expects a  ConfigMap to be present in the operator namespace. This ConfigMap was missing from the Helm chart, causing errors on startup when using the official image.

## Testing

- Tested locally with Kind cluster
- Verified ConfigMap is created during Helm install
- Operator starts without errors after ConfigMap is available

Fixes the "ConfigMap not found" error when using official ghcr.io image.