### PR TITLE
chore(ci): upgrade golangci-lint to v1.58.1 to fix Go 1.22 export typ…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install golangci-lint and gotestsum
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.1
           go install gotest.tools/gotestsum@latest
 
       - name: Run unit tests (Machine Readable)


### PR DESCRIPTION
…echeck false positives