### PR TITLE
fix(siteapp): always (re)create /assets/<app> symlink on FPM install

### DIFF
--- a/controllers/siteapp_controller.go
+++ b/controllers/siteapp_controller.go
@@ -449,6 +449,12 @@ if [ -n "$FPM_PACKAGE" ]; then
         echo "warning: could not stage vendored wheels; app deps must be in the base image"
     fi
   fi
+  # Always (re)create the /assets/<app> symlink, not just during the one-time
+  # relocate above. The relocate block is skipped whenever the app is already on
+  # the PVC (a re-reconcile, or a retried install), and a bench step can drop
+  # sites/assets — either way the symlink goes missing and the app's frontend
+  # 404s (only the framework's /assets/frappe/* load). ln -sfn is idempotent.
+  [ -d "$DEST/$APP_NAME/public" ] && ln -sfn "$DEST/$APP_NAME/public" "/home/frappe/frappe-bench/sites/assets/$APP_NAME"
   bench --site "$SITE_NAME" clear-cache 2>/dev/null || true
   echo "Verifying site health after FPM install..."
   bench --site "$SITE_NAME" execute frappe.get_installed_apps

--- a/controllers/siteapp_controller.go
+++ b/controllers/siteapp_controller.go
@@ -653,6 +653,19 @@ func (r *SiteAppReconciler) buildAppJob(siteApp *vyogotechv1.SiteApp, jobName, c
 									MountPath: "/home/frappe/frappe-bench/sites",
 									SubPath:   "frappe-sites",
 								},
+								// sites/assets is a SEPARATE subPath overlay in the
+								// serving pods (frappebench_deployments.go) and every
+								// other job (frappesite_jobs, sitebackup, siterestore).
+								// Without the same overlay here, this job's writes to
+								// sites/assets go to the parent mount's assets subdir,
+								// which is a different bind mount than the serving pods
+								// read — so the /assets/<app> symlink never reaches them
+								// and the app's frontend 404s. Mount it identically.
+								{
+									Name:      "sites",
+									MountPath: "/home/frappe/frappe-bench/sites/assets",
+									SubPath:   "frappe-sites/assets",
+								},
 								{
 									Name:      "bench-logs",
 									MountPath: "/home/frappe/frappe-bench/logs",


### PR DESCRIPTION
## Symptom
Logging into an FPM-installed app (Frappe Builder, Wiki, …) shows **404s** on the app's own frontend assets — `/assets/<app>/frontend/...` — while the framework's `/assets/frappe/*` load fine.

## Root cause — NOT missing assets
The assets are built and present: `sites/apps/<app>/<app>/public/frontend/assets/index-*.js` exists. What's missing is the **`sites/assets/<app>` symlink** Frappe/nginx need to serve `/assets/<app>/*`.

That symlink is created **only inside the one-time relocate block** (`if SRC != DEST`). On any re-reconcile the app is already on the PVC (`SRC == DEST`), so the block is skipped and the symlink is never (re)created; a later bench step can also drop `sites/assets`. Either way every FPM app loses its frontend after the first install.

## Fix
Move an idempotent `ln -sfn "$DEST/<app>/public" sites/assets/<app>` **out** of the relocate block so it runs on every FPM install. `ln -sfn` is idempotent, so it's harmless when relocate already made it.

Verified live: creating the symlink by hand made `/assets/<app>/...` serve 200 at origin (internal nginx + cache-buster) for both the builder and wiki sites. gofmt + go build + controller tests green.

**Deploy:** needs an operator release (`v5.0.8`) + argocd `frappe-operator.yaml` bump.