### PR TITLE
fix(jobs): recreate apps.txt and use the right PVC subPath in migrate/cron/config jobs

### DIFF
--- a/controllers/siteconfig_apply.go
+++ b/controllers/siteconfig_apply.go
@@ -168,7 +168,13 @@ func buildConfigJob(sc *vyogotechv1.SiteConfig, bench *vyogotechv1.FrappeBench, 
 		return nil, nil
 	}
 
-	script := "set -e\n" + strings.Join(cmds, "\n") + "\n"
+	// Same fix as the migrate/cron Jobs: cd into the bench root, then recreate
+	// apps.txt as a symlink to sites/apps.txt from the image's apps/ dir - the
+	// site-init Job's own symlink lives in its container's writable layer and is
+	// gone by the time this Job's pod starts.
+	script := "set -e\ncd /home/frappe/frappe-bench\n" +
+		"if [ -d apps ]; then ls -1 apps > sites/apps.txt; ln -sf sites/apps.txt apps.txt; fi\n" +
+		strings.Join(cmds, "\n") + "\n"
 	jobName := fmt.Sprintf("%s-apply-%d", sc.Name, sc.Generation)
 	pvcName := fmt.Sprintf("%s-sites", bench.Name)
 	backoff := int32(3)

--- a/controllers/sitecron_controller.go
+++ b/controllers/sitecron_controller.go
@@ -122,7 +122,13 @@ func (r *SiteCronReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		timeoutSec = 3600
 	}
 
-	cmdStr := fmt.Sprintf("bench --site %s execute %s", site.Status.ResolvedDomain, siteCron.Spec.Method)
+	// Same fix as the migrate Job: bench root's apps.txt is only ever a symlink
+	// the site-init Job created in its own now-gone container layer, so recreate
+	// it from the image's apps/ dir before invoking bench.
+	cmdStr := fmt.Sprintf(
+		"cd /home/frappe/frappe-bench && { [ -d apps ] && ls -1 apps > sites/apps.txt && ln -sf sites/apps.txt apps.txt; }; bench --site %s execute %s",
+		site.Status.ResolvedDomain, siteCron.Spec.Method,
+	)
 
 	cronJob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -154,7 +160,7 @@ func (r *SiteCronReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 										{
 											Name:      "sites",
 											MountPath: "/home/frappe/frappe-bench/sites",
-											SubPath:   "sites",
+											SubPath:   "frappe-sites", // same fix as the migrate Job: "frappe-sites" is the correct subPath every other component uses
 										},
 									},
 								},

--- a/controllers/sitecron_controller_test.go
+++ b/controllers/sitecron_controller_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -145,4 +146,78 @@ func TestSiteCronReconciler_Reconcile_ValidationAndNotReady(t *testing.T) {
 			t.Errorf("expected RequeueAfter 15s, got %v", res.RequeueAfter)
 		}
 	})
+}
+
+// Same two bugs as the migrate Job: the cron-runner container mounted the sites
+// PVC at subPath "sites" instead of "frappe-sites" (an empty, unrelated slice of
+// the volume), and ran `bench` without recreating the bench-root apps.txt that
+// only ever exists as a symlink in the site-init Job's own (non-persistent)
+// container. This locks in the fix for both.
+func TestSiteCronReconciler_Reconcile_CronJobMountAndCommand(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(vyogotechv1.AddToScheme(scheme))
+
+	siteCron := &vyogotechv1.SiteCron{
+		ObjectMeta: metav1.ObjectMeta{Name: "sc1", Namespace: "tenant"},
+		Spec: vyogotechv1.SiteCronSpec{
+			SiteRef:  &vyogotechv1.NamespacedName{Name: "site1"},
+			Schedule: "0 2 * * *",
+			Method:   "app.api.nightly_sync",
+		},
+	}
+	site := &vyogotechv1.FrappeSite{
+		ObjectMeta: metav1.ObjectMeta{Name: "site1", Namespace: "tenant"},
+		Spec: vyogotechv1.FrappeSiteSpec{
+			SiteName: "primary",
+			BenchRef: &vyogotechv1.NamespacedName{Name: "bench1"},
+		},
+		Status: vyogotechv1.FrappeSiteStatus{
+			Phase:          vyogotechv1.FrappeSitePhaseReady,
+			ResolvedDomain: "primary.example.com",
+		},
+	}
+	bench := &vyogotechv1.FrappeBench{
+		ObjectMeta: metav1.ObjectMeta{Name: "bench1", Namespace: "tenant"},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(siteCron, site, bench).
+		WithStatusSubresource(siteCron).
+		Build()
+	r := &SiteCronReconciler{
+		Client:   cl,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "sc1", Namespace: "tenant"}}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	cronJob := &batchv1.CronJob{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: "site1-cron-sc1", Namespace: "tenant"}, cronJob); err != nil {
+		t.Fatalf("CronJob not created: %v", err)
+	}
+
+	mounts := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].VolumeMounts
+	if len(mounts) == 0 || mounts[0].SubPath != "frappe-sites" {
+		t.Errorf("cron-runner mount subPath = %v, want frappe-sites", mounts)
+	}
+
+	cmd := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command
+	if len(cmd) < 3 {
+		t.Fatalf("cron-runner command = %v, want a bash -c <script> triple", cmd)
+	}
+	script := cmd[2]
+	if !strings.Contains(script, "cd /home/frappe/frappe-bench") {
+		t.Errorf("cron-runner script does not cd into the bench root: %q", script)
+	}
+	if !strings.Contains(script, "ls -1 apps > sites/apps.txt") || !strings.Contains(script, "ln -sf sites/apps.txt apps.txt") {
+		t.Errorf("cron-runner script does not recreate apps.txt at the bench root: %q", script)
+	}
+	if !strings.Contains(script, "bench --site primary.example.com execute app.api.nightly_sync") {
+		t.Errorf("cron-runner script does not run bench execute against the resolved domain: %q", script)
+	}
 }

--- a/controllers/sitemigration_controller.go
+++ b/controllers/sitemigration_controller.go
@@ -113,7 +113,16 @@ func (r *SiteMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	cmdStr := fmt.Sprintf("bench --site %s migrate", site.Status.ResolvedDomain)
+	// bench reads apps.txt from the bench root, but that file only exists as a
+	// symlink the site-init Job creates in ITS OWN container's writable layer
+	// (site_init.sh: "ln -sf sites/apps.txt apps.txt") - only sites/ is the
+	// persistent volume, so the symlink is gone by the time this Job's pod
+	// starts fresh. Recreate it from the image's apps/ dir (the source of
+	// truth) before invoking bench, same as site_init.sh does.
+	cmdStr := fmt.Sprintf(
+		"cd /home/frappe/frappe-bench && { [ -d apps ] && ls -1 apps > sites/apps.txt && ln -sf sites/apps.txt apps.txt; }; bench --site %s migrate",
+		site.Status.ResolvedDomain,
+	)
 	if siteMigration.Spec.SkipFixtures {
 		cmdStr += " --skip-fixtures"
 	}
@@ -142,9 +151,13 @@ func (r *SiteMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 							Resources:       vyogotechv1.ResolveJobResources(bench, vyogotechv1.JobKindMigration),
 							VolumeMounts: []corev1.VolumeMount{
 								{
+									// Every other Job/Deployment in this operator mounts the sites
+									// PVC at the "frappe-sites" subPath - this one used "sites",
+									// an unrelated (empty) slice of the same PVC, so the site this
+									// Job was meant to migrate looked like it did not exist at all.
 									Name:      "sites",
 									MountPath: "/home/frappe/frappe-bench/sites",
-									SubPath:   "sites",
+									SubPath:   "frappe-sites",
 								},
 							},
 						},

--- a/controllers/sitemigration_controller_test.go
+++ b/controllers/sitemigration_controller_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -136,4 +137,79 @@ func TestSiteMigrationReconciler_Reconcile_ValidationAndNotReady(t *testing.T) {
 			t.Errorf("expected RequeueAfter 15s, got %v", res.RequeueAfter)
 		}
 	})
+}
+
+// The migrate Job used to mount the sites PVC at subPath "sites" - an empty,
+// unrelated slice of the volume - instead of "frappe-sites", where every other
+// component in the operator actually stores site data. It also invoked `bench`
+// without first recreating apps.txt at the bench root, which only ever exists as
+// a symlink the site-init Job leaves in its own (non-persistent) container
+// layer. Both bugs made `bench migrate` fail against a site that was, in
+// reality, present and healthy. This locks in the fix for both.
+func TestSiteMigrationReconciler_Reconcile_JobMountAndCommand(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(vyogotechv1.AddToScheme(scheme))
+
+	siteMigration := &vyogotechv1.SiteMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "sm1", Namespace: "tenant"},
+		Spec: vyogotechv1.SiteMigrationSpec{
+			SiteRef:             &vyogotechv1.NamespacedName{Name: "site1"},
+			BackupBeforeMigrate: false,
+		},
+	}
+	site := &vyogotechv1.FrappeSite{
+		ObjectMeta: metav1.ObjectMeta{Name: "site1", Namespace: "tenant"},
+		Spec: vyogotechv1.FrappeSiteSpec{
+			SiteName: "primary",
+			BenchRef: &vyogotechv1.NamespacedName{Name: "bench1"},
+		},
+		Status: vyogotechv1.FrappeSiteStatus{
+			Phase:          vyogotechv1.FrappeSitePhaseReady,
+			ResolvedDomain: "primary.example.com",
+		},
+	}
+	bench := &vyogotechv1.FrappeBench{
+		ObjectMeta: metav1.ObjectMeta{Name: "bench1", Namespace: "tenant"},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(siteMigration, site, bench).
+		WithStatusSubresource(siteMigration).
+		Build()
+	r := &SiteMigrationReconciler{
+		Client:   cl,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "sm1", Namespace: "tenant"}}); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	job := &batchv1.Job{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: "site1-migrate-sm1", Namespace: "tenant"}, job); err != nil {
+		t.Fatalf("migrate Job not created: %v", err)
+	}
+
+	mounts := job.Spec.Template.Spec.Containers[0].VolumeMounts
+	if len(mounts) == 0 || mounts[0].SubPath != "frappe-sites" {
+		t.Errorf("migrate Job mount subPath = %v, want frappe-sites", mounts)
+	}
+
+	cmd := job.Spec.Template.Spec.Containers[0].Command
+	if len(cmd) < 3 {
+		t.Fatalf("migrate Job command = %v, want a bash -c <script> triple", cmd)
+	}
+	script := cmd[2]
+	if !strings.Contains(script, "cd /home/frappe/frappe-bench") {
+		t.Errorf("migrate Job script does not cd into the bench root: %q", script)
+	}
+	if !strings.Contains(script, "ls -1 apps > sites/apps.txt") || !strings.Contains(script, "ln -sf sites/apps.txt apps.txt") {
+		t.Errorf("migrate Job script does not recreate apps.txt at the bench root: %q", script)
+	}
+	if !strings.Contains(script, "bench --site primary.example.com migrate") {
+		t.Errorf("migrate Job script does not run bench migrate against the resolved domain: %q", script)
+	}
 }


### PR DESCRIPTION
Two separate bugs made bench commands fail against sites that were actually
healthy, surfaced while validating transaction-mode PgBouncer pooling for the
StackGres work end to end:

1. **apps.txt missing at the bench root.** `bench` reads it via
   `bench_helper.py`'s `get_apps()`, which hardcodes `sites_path="."` - the
   general `sites/apps.txt` convention does not apply to this call. That file
   only ever existed as a symlink the site-init Job creates in its OWN
   container's writable layer (`site_init.sh`: `ln -sf sites/apps.txt
   apps.txt`); since only `sites/` is the persistent volume, the symlink is
   gone by the time any other Job's pod starts fresh. Recreate it from the
   image's `apps/` dir (the source of truth) before invoking bench, same as
   `site_init.sh` already does.

2. **Wrong PVC subPath.** The migrate and cron Jobs mounted the sites PVC at
   subPath `"sites"` - an empty, unrelated slice of the volume - while every
   other component (gunicorn, workers, site-init, backup, restore, domain
   alias) correctly uses `"frappe-sites"`. A site that exists and is Ready
   still looked like it "does not exist" from inside these two Jobs.

Fixed in `sitemigration_controller.go` (bug 1+2) and `sitecron_controller.go`
(bug 1+2); `siteconfig_apply.go` only had bug 1, its subPath was already
correct.

Verified live on an OCP cluster: `bench new-site` and a full `bench migrate`
both succeed through a real transaction-mode PgBouncer pooler in front of
Postgres - the pooling mode our own comment warned would break them turned
out not to be the problem at all.

Added regression tests for both bugs, verified red against the original code
before restoring the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)